### PR TITLE
feat: pattern mining with drain

### DIFF
--- a/examples/getting-started/docker-compose.yaml
+++ b/examples/getting-started/docker-compose.yaml
@@ -1,34 +1,17 @@
 ---
-version: "3"
+# version: "3"
 
 networks:
   loki:
 
 services:
-  read:
-    image: grafana/loki:2.9.2
-    command: "-config.file=/etc/loki/config.yaml -target=read"
-    ports:
-      - 3101:3100
-      - 7946
-      - 9095
-    volumes:
-      - ./loki-config.yaml:/etc/loki/config.yaml
-    depends_on:
-      - minio
-    healthcheck:
-      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    networks: &loki-dns
-      loki:
-        aliases:
-          - loki
-
-  write:
-    image: grafana/loki:2.9.2
-    command: "-config.file=/etc/loki/config.yaml -target=write"
+  loki:
+    image: kolesnikovae/loki-loggerinfo:latest
+    #  build:
+    #    context: ../../
+    #    dockerfile: cmd/loki/Dockerfile
+    #    no_cache: true
+    command: "-config.file=/etc/loki/config.yaml"
     ports:
       - 3102:3100
       - 7946
@@ -40,10 +23,14 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    environment:
+      LOG_CLUSTER_DEPTH: "4"
     depends_on:
       - minio
     networks:
-      <<: *loki-dns
+      loki:
+        aliases:
+          - loki
 
   promtail:
     image: grafana/promtail:2.9.2
@@ -121,8 +108,7 @@ services:
   gateway:
     image: nginx:latest
     depends_on:
-      - read
-      - write
+      - loki
     entrypoint:
       - sh
       - -euc
@@ -147,31 +133,31 @@ services:
             }
 
             location = /api/prom/push {
-              proxy_pass       http://write:3100\$$request_uri;
+              proxy_pass       http://loki:3100\$$request_uri;
             }
 
             location = /api/prom/tail {
-              proxy_pass       http://read:3100\$$request_uri;
+              proxy_pass       http://loki:3100\$$request_uri;
               proxy_set_header Upgrade \$$http_upgrade;
               proxy_set_header Connection "upgrade";
             }
 
             location ~ /api/prom/.* {
-              proxy_pass       http://read:3100\$$request_uri;
+              proxy_pass       http://loki:3100\$$request_uri;
             }
 
             location = /loki/api/v1/push {
-              proxy_pass       http://write:3100\$$request_uri;
+              proxy_pass       http://loki:3100\$$request_uri;
             }
 
             location = /loki/api/v1/tail {
-              proxy_pass       http://read:3100\$$request_uri;
+              proxy_pass       http://loki:3100\$$request_uri;
               proxy_set_header Upgrade \$$http_upgrade;
               proxy_set_header Connection "upgrade";
             }
 
             location ~ /loki/api/.* {
-              proxy_pass       http://read:3100\$$request_uri;
+              proxy_pass       http://loki:3100\$$request_uri;
             }
           }
         }

--- a/examples/getting-started/promtail-local-config.yaml
+++ b/examples/getting-started/promtail-local-config.yaml
@@ -19,4 +19,6 @@ scrape_configs:
       - source_labels: ['__meta_docker_container_name']
         regex: '/(.*)'
         target_label: 'container'
-
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: 'service_name'

--- a/examples/getting-started/query.sh
+++ b/examples/getting-started/query.sh
@@ -1,0 +1,4 @@
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{ "query": "{service_name=\"getting-started-gateway-1\"}", "from": 0, "to": 5709269800000000000}' \
+  http://localhost:3102/loki/api/v1/patterns | jq .

--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/loki/pkg/ingester/index"
 	"github.com/grafana/loki/pkg/ingester/wal"
 	"github.com/grafana/loki/pkg/iter"
+	"github.com/grafana/loki/pkg/loggerinfo"
 	"github.com/grafana/loki/pkg/loghttp/push"
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/loki/pkg/logql"
@@ -216,6 +217,7 @@ func (i *instance) Push(ctx context.Context, req *logproto.PushRequest) error {
 	defer recordPool.PutRecord(record)
 	rateLimitWholeStream := i.limiter.limits.ShardStreams(i.instanceID).Enabled
 
+	loggerinfo.Push(req)
 	var appendErr error
 	for _, reqStream := range req.Streams {
 

--- a/pkg/loggerinfo/drain/REAMDE.md
+++ b/pkg/loggerinfo/drain/REAMDE.md
@@ -1,0 +1,1 @@
+Fork of https://github.com/faceair/drain with minor adjustments.

--- a/pkg/loggerinfo/drain/drain.go
+++ b/pkg/loggerinfo/drain/drain.go
@@ -1,0 +1,488 @@
+// MIT License
+//
+// Copyright (c) 2022 faceair
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package drain
+
+import (
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+	"golang.org/x/exp/slices"
+)
+
+type Config struct {
+	maxNodeDepth    int
+	LogClusterDepth int
+	SimTh           float64
+	MaxChildren     int
+	ExtraDelimiters []string
+	MaxClusters     int
+	ParamString     string
+}
+
+type LogCluster struct {
+	id     int
+	Size   int
+	Tokens []string
+
+	Samples []string
+	Volume  Volume
+}
+
+const (
+	timeResolution = int64(time.Second * 10)
+	maxSamples     = 10
+
+	defaultVolumeSize = 500
+)
+
+func (c *LogCluster) getTemplate() string {
+	return strings.Join(c.Tokens, " ")
+}
+
+func (c *LogCluster) String() string {
+	return c.getTemplate()
+}
+
+func truncateTimestamp(ts int64) int64 { return ts - ts%timeResolution }
+
+type Volume struct {
+	Values [][2]int64 // 0 timestamp, 1 count.
+}
+
+func initVolume(ts int64) Volume {
+	v := Volume{Values: make([][2]int64, 1, defaultVolumeSize)}
+	v.Values[0] = [2]int64{ts, 1}
+	return v
+}
+
+// ForRange returns a new Volume with only the values
+// in the given range [start:end).
+func (x *Volume) ForRange(start, end int64) *Volume {
+	if len(x.Values) == 0 {
+		// Should not be the case.
+		return new(Volume)
+	}
+	first := x.Values[0][0]
+	last := x.Values[len(x.Values)-1][0]
+	if start >= end || first >= end || last < start {
+		return new(Volume)
+	}
+	var lo int
+	if start > first {
+		lo = sort.Search(len(x.Values), func(i int) bool {
+			return x.Values[i][0] >= start
+		})
+	}
+	hi := len(x.Values)
+	if end < last {
+		hi = sort.Search(len(x.Values), func(i int) bool {
+			return x.Values[i][0] >= end
+		})
+	}
+	return &Volume{
+		Values: x.Values[lo:hi],
+	}
+}
+
+func (x *Volume) Matches() int64 {
+	var m int64
+	for i := range x.Values {
+		m += x.Values[i][1]
+	}
+	return m
+}
+
+func (x *Volume) Add(ts int64) {
+	t := truncateTimestamp(ts)
+	first := x.Values[0][0] // can't be empty
+	last := x.Values[len(x.Values)-1][0]
+	switch {
+	case last == t:
+		// Should be the most common case.
+		x.Values[len(x.Values)-1][1]++
+	case first > t:
+		// Prepend.
+		x.Values = slices.Grow(x.Values, 1)
+		copy(x.Values[1:], x.Values)
+		x.Values[0] = [2]int64{t, 1}
+	case last < t:
+		// Append.
+		x.Values = append(x.Values, [2]int64{t, 1})
+	default:
+		// Find with binary search and update.
+		index := sort.Search(len(x.Values), func(i int) bool {
+			return x.Values[i][1] >= t
+		})
+		if index < len(x.Values) && x.Values[index][1] == t {
+			x.Values[index][1]++
+		} else {
+			x.Values = slices.Insert(x.Values, index, [2]int64{t, 1})
+		}
+	}
+}
+
+func (c *LogCluster) append(content string, ts int64) {
+	c.Volume.Add(ts)
+	// TODO: Should we sample lines randomly? Keep last N?
+	if len(c.Samples) < maxSamples {
+		c.Samples = append(c.Samples, content)
+	}
+}
+
+func createLogClusterCache(maxSize int) *LogClusterCache {
+	if maxSize == 0 {
+		maxSize = math.MaxInt
+	}
+	cache, _ := simplelru.NewLRU(maxSize, nil)
+	return &LogClusterCache{
+		cache: cache,
+	}
+}
+
+type LogClusterCache struct {
+	cache simplelru.LRUCache
+}
+
+func (c *LogClusterCache) Values() []*LogCluster {
+	values := make([]*LogCluster, 0)
+	for _, key := range c.cache.Keys() {
+		if value, ok := c.cache.Peek(key); ok {
+			values = append(values, value.(*LogCluster))
+		}
+	}
+	return values
+}
+
+func (c *LogClusterCache) Set(key int, cluster *LogCluster) {
+	c.cache.Add(key, cluster)
+}
+
+func (c *LogClusterCache) Iterate(fn func(*LogCluster) bool) {
+	for _, key := range c.cache.Keys() {
+		if value, ok := c.cache.Peek(key); ok {
+			if !fn(value.(*LogCluster)) {
+				return
+			}
+		}
+	}
+}
+
+func (c *LogClusterCache) Get(key int) *LogCluster {
+	cluster, ok := c.cache.Get(key)
+	if !ok {
+		return nil
+	}
+	return cluster.(*LogCluster)
+}
+
+func createNode() *Node {
+	return &Node{
+		keyToChildNode: make(map[string]*Node),
+		clusterIDs:     make([]int, 0),
+	}
+}
+
+type Node struct {
+	keyToChildNode map[string]*Node
+	clusterIDs     []int
+}
+
+func DefaultConfig() *Config {
+	return &Config{
+		LogClusterDepth: 4,
+		SimTh:           0.4,
+		MaxChildren:     100,
+		ParamString:     "<*>",
+	}
+}
+
+func New(config *Config) *Drain {
+	if config.LogClusterDepth < 3 {
+		panic("depth argument must be at least 3")
+	}
+	config.maxNodeDepth = config.LogClusterDepth - 2
+
+	d := &Drain{
+		config:      config,
+		rootNode:    createNode(),
+		idToCluster: createLogClusterCache(config.MaxClusters),
+	}
+	return d
+}
+
+type Drain struct {
+	config          *Config
+	rootNode        *Node
+	idToCluster     *LogClusterCache
+	clustersCounter int
+}
+
+func (d *Drain) Clusters() []*LogCluster {
+	return d.idToCluster.Values()
+}
+
+func (d *Drain) Iterate(fn func(*LogCluster) bool) {
+	d.idToCluster.Iterate(fn)
+}
+
+func (d *Drain) Train(content string, ts int64) *LogCluster {
+	contentTokens := d.getContentAsTokens(content)
+
+	matchCluster := d.treeSearch(d.rootNode, contentTokens, d.config.SimTh, false)
+	// Match no existing log cluster
+	if matchCluster == nil {
+		d.clustersCounter++
+		clusterID := d.clustersCounter
+		matchCluster = &LogCluster{
+			Tokens: contentTokens,
+			id:     clusterID,
+			Size:   1,
+
+			Samples: []string{content},
+			Volume:  initVolume(ts),
+		}
+		d.idToCluster.Set(clusterID, matchCluster)
+		d.addSeqToPrefixTree(d.rootNode, matchCluster)
+	} else {
+		newTemplateTokens := d.createTemplate(contentTokens, matchCluster.Tokens)
+		matchCluster.Tokens = newTemplateTokens
+		matchCluster.Size++
+		matchCluster.append(content, ts)
+		// Touch cluster to update its state in the cache.
+		d.idToCluster.Get(matchCluster.id)
+	}
+	return matchCluster
+}
+
+// Match against an already existing cluster. Match shall be perfect (sim_th=1.0). New cluster will not be created as a result of this call, nor any cluster modifications.
+func (d *Drain) Match(content string) *LogCluster {
+	contentTokens := d.getContentAsTokens(content)
+	matchCluster := d.treeSearch(d.rootNode, contentTokens, 1.0, true)
+	return matchCluster
+}
+
+func (d *Drain) getContentAsTokens(content string) []string {
+	content = strings.TrimSpace(content)
+	for _, extraDelimiter := range d.config.ExtraDelimiters {
+		content = strings.Replace(content, extraDelimiter, " ", -1)
+	}
+	return strings.Split(content, " ")
+}
+
+func (d *Drain) treeSearch(rootNode *Node, tokens []string, simTh float64, includeParams bool) *LogCluster {
+	tokenCount := len(tokens)
+
+	// at first level, children are grouped by token (word) count
+	curNode, ok := rootNode.keyToChildNode[strconv.Itoa(tokenCount)]
+
+	// no template with same token count yet
+	if !ok {
+		return nil
+	}
+
+	// handle case of empty log string - return the single cluster in that group
+	if tokenCount == 0 {
+		return d.idToCluster.Get(curNode.clusterIDs[0])
+	}
+
+	// find the leaf node for this log - a path of nodes matching the first N tokens (N=tree depth)
+	curNodeDepth := 1
+	for _, token := range tokens {
+		// at max depth
+		if curNodeDepth >= d.config.maxNodeDepth {
+			break
+		}
+
+		// this is last token
+		if curNodeDepth == tokenCount {
+			break
+		}
+
+		keyToChildNode := curNode.keyToChildNode
+		curNode, ok = keyToChildNode[token]
+		if !ok { // no exact next token exist, try wildcard node
+			curNode, ok = keyToChildNode[d.config.ParamString]
+		}
+		if !ok { // no wildcard node exist
+			return nil
+		}
+		curNodeDepth++
+	}
+
+	// get best match among all clusters with same prefix, or None if no match is above sim_th
+	cluster := d.fastMatch(curNode.clusterIDs, tokens, simTh, includeParams)
+	return cluster
+}
+
+// fastMatch Find the best match for a log message (represented as tokens) versus a list of clusters
+func (d *Drain) fastMatch(clusterIDs []int, tokens []string, simTh float64, includeParams bool) *LogCluster {
+	var matchCluster, maxCluster *LogCluster
+
+	maxSim := -1.0
+	maxParamCount := -1
+	for _, clusterID := range clusterIDs {
+		// Try to retrieve cluster from cache with bypassing eviction
+		// algorithm as we are only testing candidates for a match.
+		cluster := d.idToCluster.Get(clusterID)
+		if cluster == nil {
+			continue
+		}
+		curSim, paramCount := d.getSeqDistance(cluster.Tokens, tokens, includeParams)
+		if curSim > maxSim || (curSim == maxSim && paramCount > maxParamCount) {
+			maxSim = curSim
+			maxParamCount = paramCount
+			maxCluster = cluster
+		}
+	}
+	if maxSim >= simTh {
+		matchCluster = maxCluster
+	}
+	return matchCluster
+}
+
+func (d *Drain) getSeqDistance(seq1, seq2 []string, includeParams bool) (float64, int) {
+	if len(seq1) != len(seq2) {
+		panic("seq1 seq2 be of same length")
+	}
+
+	simTokens := 0
+	paramCount := 0
+	for i := range seq1 {
+		token1 := seq1[i]
+		token2 := seq2[i]
+		if token1 == d.config.ParamString {
+			paramCount++
+		} else if token1 == token2 {
+			simTokens++
+		}
+	}
+	if includeParams {
+		simTokens += paramCount
+	}
+	retVal := float64(simTokens) / float64(len(seq1))
+	return retVal, paramCount
+}
+
+func (d *Drain) addSeqToPrefixTree(rootNode *Node, cluster *LogCluster) {
+	tokenCount := len(cluster.Tokens)
+	tokenCountStr := strconv.Itoa(tokenCount)
+
+	firstLayerNode, ok := rootNode.keyToChildNode[tokenCountStr]
+	if !ok {
+		firstLayerNode = createNode()
+		rootNode.keyToChildNode[tokenCountStr] = firstLayerNode
+	}
+	curNode := firstLayerNode
+
+	// handle case of empty log string
+	if tokenCount == 0 {
+		curNode.clusterIDs = append(curNode.clusterIDs, cluster.id)
+		return
+	}
+
+	currentDepth := 1
+	for _, token := range cluster.Tokens {
+		// if at max depth or this is last token in template - add current log cluster to the leaf node
+		if (currentDepth >= d.config.maxNodeDepth) || currentDepth >= tokenCount {
+			// clean up stale clusters before adding a new one.
+			newClusterIDs := make([]int, 0, len(curNode.clusterIDs))
+			for _, clusterID := range curNode.clusterIDs {
+				if d.idToCluster.Get(clusterID) != nil {
+					newClusterIDs = append(newClusterIDs, clusterID)
+				}
+			}
+			newClusterIDs = append(newClusterIDs, cluster.id)
+			curNode.clusterIDs = newClusterIDs
+			break
+		}
+
+		// if token not matched in this layer of existing tree.
+		if _, ok = curNode.keyToChildNode[token]; !ok {
+			// if token not matched in this layer of existing tree.
+			if !d.hasNumbers(token) {
+				if _, ok = curNode.keyToChildNode[d.config.ParamString]; ok {
+					if len(curNode.keyToChildNode) < d.config.MaxChildren {
+						newNode := createNode()
+						curNode.keyToChildNode[token] = newNode
+						curNode = newNode
+					} else {
+						curNode = curNode.keyToChildNode[d.config.ParamString]
+					}
+				} else {
+					if len(curNode.keyToChildNode)+1 < d.config.MaxChildren {
+						newNode := createNode()
+						curNode.keyToChildNode[token] = newNode
+						curNode = newNode
+					} else if len(curNode.keyToChildNode)+1 == d.config.MaxChildren {
+						newNode := createNode()
+						curNode.keyToChildNode[d.config.ParamString] = newNode
+						curNode = newNode
+					} else {
+						curNode = curNode.keyToChildNode[d.config.ParamString]
+					}
+				}
+			} else {
+				if _, ok = curNode.keyToChildNode[d.config.ParamString]; !ok {
+					newNode := createNode()
+					curNode.keyToChildNode[d.config.ParamString] = newNode
+					curNode = newNode
+				} else {
+					curNode = curNode.keyToChildNode[d.config.ParamString]
+				}
+			}
+		} else {
+			// if the token is matched
+			curNode = curNode.keyToChildNode[token]
+		}
+
+		currentDepth++
+	}
+}
+
+func (d *Drain) hasNumbers(s string) bool {
+	for _, c := range s {
+		if unicode.IsNumber(c) {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *Drain) createTemplate(seq1, seq2 []string) []string {
+	if len(seq1) != len(seq2) {
+		panic("seq1 seq2 be of same length")
+	}
+	retVal := make([]string, len(seq2))
+	copy(retVal, seq2)
+	for i := range seq1 {
+		if seq1[i] != seq2[i] {
+			retVal[i] = d.config.ParamString
+		}
+	}
+	return retVal
+}

--- a/pkg/loggerinfo/drain/drain_test.go
+++ b/pkg/loggerinfo/drain/drain_test.go
@@ -1,0 +1,82 @@
+package drain
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestForRange(t *testing.T) {
+	testCases := []struct {
+		name     string
+		volume   *Volume
+		start    int64
+		end      int64
+		expected *Volume
+	}{
+		{
+			name:     "Empty Volume",
+			volume:   &Volume{},
+			start:    1,
+			end:      10,
+			expected: &Volume{},
+		},
+		{
+			name:     "No Overlap",
+			volume:   &Volume{Values: [][2]int64{{1, 2}, {3, 4}, {5, 6}}},
+			start:    10,
+			end:      20,
+			expected: &Volume{},
+		},
+		{
+			name:     "Complete Overlap",
+			volume:   &Volume{Values: [][2]int64{{1, 2}, {3, 4}, {5, 6}}},
+			start:    0,
+			end:      10,
+			expected: &Volume{Values: [][2]int64{{1, 2}, {3, 4}, {5, 6}}},
+		},
+		{
+			name:     "Partial Overlap",
+			volume:   &Volume{Values: [][2]int64{{1, 2}, {3, 4}, {5, 6}}},
+			start:    2,
+			end:      4,
+			expected: &Volume{Values: [][2]int64{{3, 4}}},
+		},
+		{
+			name:     "Single Element in Range",
+			volume:   &Volume{Values: [][2]int64{{1, 2}, {3, 4}, {5, 6}}},
+			start:    3,
+			end:      4,
+			expected: &Volume{Values: [][2]int64{{3, 4}}},
+		},
+		{
+			name:     "Start Before First Element",
+			volume:   &Volume{Values: [][2]int64{{1, 2}, {3, 4}, {5, 6}}},
+			start:    0,
+			end:      4,
+			expected: &Volume{Values: [][2]int64{{1, 2}, {3, 4}}},
+		},
+		{
+			name:     "End After Last Element",
+			volume:   &Volume{Values: [][2]int64{{1, 2}, {3, 4}, {5, 6}}},
+			start:    4,
+			end:      10,
+			expected: &Volume{Values: [][2]int64{{5, 6}}},
+		},
+		{
+			name:     "Start and End Before First Element",
+			volume:   &Volume{Values: [][2]int64{{1, 2}, {3, 4}, {5, 6}}},
+			start:    0,
+			end:      1,
+			expected: &Volume{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.volume.ForRange(tc.start, tc.end)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/loggerinfo/loggerinfo.go
+++ b/pkg/loggerinfo/loggerinfo.go
@@ -1,0 +1,166 @@
+package loggerinfo
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"sync"
+
+	"github.com/grafana/loki/pkg/push"
+	"github.com/prometheus/prometheus/model/labels"
+	promql_parser "github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/grafana/loki/pkg/loggerinfo/drain"
+	"github.com/grafana/loki/pkg/logproto"
+	"github.com/grafana/loki/pkg/logql/syntax"
+)
+
+var loggerinfo LoggerInfo
+
+type LoggerInfo struct {
+	m sync.Mutex
+
+	services map[string]*serviceLoggerInfo
+}
+
+const serviceNameLabel = "service_name"
+
+func Push(req *logproto.PushRequest) { loggerinfo.Push(req) }
+
+func (s *LoggerInfo) Push(req *logproto.PushRequest) {
+	for _, stream := range req.Streams {
+		p, _ := promql_parser.ParseMetric(stream.Labels)
+		if sn := p.Get(serviceNameLabel); sn != "" {
+			s.serviceInstance(sn).push(stream)
+		}
+	}
+}
+
+func (s *LoggerInfo) serviceInstance(serviceName string) *serviceLoggerInfo {
+	s.m.Lock()
+	defer s.m.Unlock()
+	if s.services == nil {
+		s.services = make(map[string]*serviceLoggerInfo)
+	}
+	si, ok := s.services[serviceName]
+	if !ok {
+		si = newServiceLoggerInfo()
+		s.services[serviceName] = si
+	}
+	return si
+}
+
+type serviceLoggerInfo struct {
+	m sync.Mutex
+
+	patterns *drain.Drain
+}
+
+var drainConfig = &drain.Config{
+	LogClusterDepth: readConfig[int]("LOG_CLUSTER_DEPTH", strconv.Atoi, 4),
+	SimTh:           0.4,
+	MaxChildren:     100,
+	ParamString:     "<*>",
+	MaxClusters:     0,
+}
+
+func readConfig[T any](name string, fn func(string) (T, error), d T) T {
+	v := os.Getenv(name)
+	if v == "" {
+		return d
+	}
+	c, err := fn(v)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func newServiceLoggerInfo() *serviceLoggerInfo {
+	return &serviceLoggerInfo{
+		patterns: drain.New(drainConfig),
+	}
+}
+
+func (s *serviceLoggerInfo) push(stream push.Stream) {
+	for _, entry := range stream.Entries {
+		s.patterns.Train(entry.Line, entry.Timestamp.UnixNano())
+	}
+}
+
+type PatternsRequest struct {
+	Expr      string `json:"query"`
+	StartTime int64  `json:"from"`
+	EndTime   int64  `json:"to"`
+}
+
+type PatternsResponse struct {
+	Patterns []*Pattern `json:"patterns"`
+}
+
+type Pattern struct {
+	Name    string     `json:"name"`
+	Pattern string     `json:"pattern"`
+	Samples []string   `json:"sampleLogLines"`
+	Volume  [][2]int64 `json:"volumeTimeSeries"`
+	Matches int64      `json:"matches"`
+}
+
+func Patterns(w http.ResponseWriter, r *http.Request) {
+	var req PatternsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		_, _ = w.Write([]byte(err.Error()))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	svcName, err := getServiceName(req.Expr)
+	if err != nil {
+		_, _ = w.Write([]byte(err.Error()))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	patterns := loggerinfo.serviceInstance(svcName).getPatterns(req.StartTime, req.EndTime)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(patterns)
+}
+
+func getServiceName(expr string) (string, error) {
+	matchers, err := syntax.ParseMatchers(expr, true)
+	if err != nil {
+		return "", err
+	}
+	for _, m := range matchers {
+		if m.Name == serviceNameLabel && m.Type == labels.MatchEqual {
+			return m.Value, nil
+		}
+	}
+	return "", errors.New("service_name matcher is required")
+}
+
+func (s *serviceLoggerInfo) getPatterns(start, end int64) PatternsResponse {
+	s.m.Lock()
+	defer s.m.Unlock()
+	resp := PatternsResponse{Patterns: make([]*Pattern, 0, 1<<10)}
+	s.patterns.Iterate(func(cluster *drain.LogCluster) bool {
+		volume := cluster.Volume.ForRange(start, end)
+		matches := volume.Matches()
+		if matches == 0 {
+			return true
+		}
+		resp.Patterns = append(resp.Patterns, &Pattern{
+			Name:    "", // TODO
+			Pattern: cluster.String(),
+			Matches: matches,
+			Volume:  volume.Values,
+			Samples: cluster.Samples,
+		})
+		return true
+	})
+	sort.Slice(resp.Patterns, func(i, j int) bool {
+		return resp.Patterns[i].Pattern <= resp.Patterns[j].Pattern
+	})
+	return resp
+}

--- a/pkg/loki/modules.go
+++ b/pkg/loki/modules.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prometheus/common/version"
 
 	"github.com/grafana/loki/pkg/bloomcompactor"
+	"github.com/grafana/loki/pkg/loggerinfo"
 	"github.com/grafana/loki/pkg/logqlmodel/stats"
 
 	"github.com/grafana/loki/pkg/analytics"
@@ -1028,6 +1029,7 @@ func (t *Loki) initQueryFrontend() (_ services.Service, err error) {
 	t.Server.HTTP.Path("/loki/api/v1/query").Methods("GET", "POST").Handler(frontendHandler)
 	t.Server.HTTP.Path("/loki/api/v1/label").Methods("GET", "POST").Handler(frontendHandler)
 	t.Server.HTTP.Path("/loki/api/v1/labels").Methods("GET", "POST").Handler(frontendHandler)
+	t.Server.HTTP.Path("/loki/api/v1/patterns").Methods("GET", "POST").HandlerFunc(loggerinfo.Patterns)
 	t.Server.HTTP.Path("/loki/api/v1/label/{name}/values").Methods("GET", "POST").Handler(frontendHandler)
 	t.Server.HTTP.Path("/loki/api/v1/series").Methods("GET", "POST").Handler(frontendHandler)
 	t.Server.HTTP.Path("/loki/api/v1/index/stats").Methods("GET", "POST").Handler(frontendHandler)


### PR DESCRIPTION
A basic implementation of pattern mining with Drain. Persistence, durability, reliability, performance, and many other things are out of scope of the experiment.

How to test:
 1. Run [docker-compose](https://github.com/grafana/loki-hackathon-2024-03-logger-info/blob/feat/pattern-mining-with-drain/examples/getting-started/docker-compose.yaml).
 2.  Query patterns with curl: [./examples/getting-started/query.sh](https://github.com/grafana/loki-hackathon-2024-03-logger-info/blob/feat/pattern-mining-with-drain/examples/getting-started/query.sh). The output should be similar to:

```json
{
  "patterns": [
    {
      "name": "",
      "pattern": "192.168.144.7 - - <*> +0000] \"POST /loki/api/v1/push HTTP/1.1\" <*> <*> \"-\" \"promtail/2.9.2\"",
      "sampleLogLines": [
        "192.168.144.7 - - [01/Mar/2024:08:27:33 +0000] \"POST /loki/api/v1/push HTTP/1.1\" 204 0 \"-\" \"promtail/2.9.2\"",
        "192.168.144.7 - - [01/Mar/2024:08:27:34 +0000] \"POST /loki/api/v1/push HTTP/1.1\" 502 157 \"-\" \"promtail/2.9.2\"",
        "192.168.144.7 - - [01/Mar/2024:08:27:45 +0000] \"POST /loki/api/v1/push HTTP/1.1\" 499 0 \"-\" \"promtail/2.9.2\"",
        "192.168.144.7 - - [01/Mar/2024:08:27:47 +0000] \"POST /loki/api/v1/push HTTP/1.1\" 502 157 \"-\" \"promtail/2.9.2\"",
      ],
      "volumeTimeSeries": [
        [
          1709281650000000000,
          1
        ],
        [
          1709281660000000000,
          3
        ],
        ...
      ],
      "matches": 1003
    },
    {
      "name": "",
      "pattern": "2024/03/01 08:27:34 [error] 31#31: *1 connect() failed (111: Connection refused) while connecting to upstream, client: 192.168.144.7, server: , request: \"POST /loki/api/v1/push HTTP/1.1\", upstream: \"http://192.168.144.4:3100/loki/api/v1/push\", host: \"gateway:3100\"",
      "sampleLogLines": [
        "2024/03/01 08:27:34 [error] 31#31: *1 connect() failed (111: Connection refused) while connecting to upstream, client: 192.168.144.7, server: , request: \"POST /loki/api/v1/push HTTP/1.1\", upstream: \"http://192.168.144.4:3100/loki/api/v1/push\", host: \"gateway:3100\""
      ],
      "volumeTimeSeries": [
        [
          1709281654862583000,
          1
        ]
      ],
      "matches": 1
    },
    {
      "name": "",
      "pattern": "2024/03/01 <*> [error] 33#33: *266 loki could not be resolved (3: Host not found), client: 192.168.144.7, server: , request: \"POST /loki/api/v1/push HTTP/1.1\", host: \"gateway:3100\"",
      "sampleLogLines": [
        "2024/03/01 08:27:47 [error] 33#33: *266 loki could not be resolved (3: Host not found), client: 192.168.144.7, server: , request: \"POST /loki/api/v1/push HTTP/1.1\", host: \"gateway:3100\"",
        "2024/03/01 08:27:49 [error] 33#33: *266 loki could not be resolved (3: Host not found), client: 192.168.144.7, server: , request: \"POST /loki/api/v1/push HTTP/1.1\", host: \"gateway:3100\"",
      ],
      "volumeTimeSeries": [
        [
          1709281660000000000,
          1
        ],
        ...
      ],
      "matches": 3
    }
  ]
}
```

Note that, as of now, the backend requires a query to target a specific service (e.g., `{"service_name"="my-service"}`.)

TODO:
 - [ ] Structured logs: JSON and logfmt – need a better tokenizer
 - [ ] Make LogQL to filter by pattern
 - [ ] Pattern naming
 - [ ] Field classification (named entity recognition, type detection, etc)

/cc @cyriltovena 