### PR TITLE
change service label from `service` to `service_name`

### DIFF
--- a/pkg/loggerinfo/loggerinfo.go
+++ b/pkg/loggerinfo/loggerinfo.go
@@ -29,7 +29,7 @@ type LoggerInfo struct {
 	services map[string]*serviceLoggerInfo
 }
 
-const serviceNameLabel = "service"
+const serviceNameLabel = "service_name"
 
 func Push(req *logproto.PushRequest) { loggerinfo.Push(req) }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes `service` to `service_name`